### PR TITLE
Friend request endpoints

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -16,7 +16,14 @@ class Users(models.Model):
     joined_at = models.DateTimeField(auto_now_add=True)
     email = models.CharField(max_length=255)
     role_id = models.ForeignKey('Roles', on_delete=models.CASCADE)
+    friend_request = models.ManyToManyField('self', through='FriendList', through_fields=('user', 'friend'), symmetrical=False)
 
+
+class FriendList(models.Model):
+    user = models.ForeignKey(Users, on_delete=models.CASCADE, related_name='user')
+    friend = models.ForeignKey(Users, on_delete=models.CASCADE, related_name='friend')
+    status = models.CharField(max_length=10, choices=(('pending', 'Pending'), ('accepted', 'Accepted'), ('rejected', 'Rejected')))
+    timestamp = models.DateTimeField(auto_now=True)
 
 class Roles(models.Model):
     name = models.CharField(max_length=255)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -78,3 +78,15 @@ class CategoriesESerializer(serializers.ModelSerializer):
     class Meta:
         model = CategoriesE
         fields = ['id', 'name', 'description']
+
+
+class FriendSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FriendList
+        fields = ('user', 'friend', 'status', 'timestamp')
+
+
+class FriendListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Users
+        fields = ('id', 'name', 'surname', 'email')

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2,7 +2,6 @@ from django.contrib.auth import authenticate, login, logout
 from django.http import JsonResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
-from django.shortcuts import render
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from .serializers import *
@@ -94,6 +93,72 @@ class ProductsViewSet(viewsets.ModelViewSet):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class Friend(viewsets.ViewSet):
+    serializer_class = FriendSerializer
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid():
+            user = serializer.validated_data.get('user')
+            friend = serializer.validated_data.get('friend')
+            status_request = serializer.validated_data.get('status')
+            if user == friend:
+                return Response({'error': 'User and friend cannot be the same'}, status=status.HTTP_400_BAD_REQUEST)
+            if user.id < 1 or friend.id < 1:
+                return Response({'error': 'User and friend IDs cannot be less than 1'}, status=status.HTTP_400_BAD_REQUEST)
+            new_friendship = FriendList.objects.create(user=user, friend=friend, status=status_request)
+            new_friendship.save()
+            return Response({'success': 'Friendship created successfully'}, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def update(self, request, pk=None):
+        try:
+            friend = FriendList.objects.get(pk=pk)
+        except FriendList.DoesNotExist:
+            return Response({'error': 'Friendship does not exist'}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.serializer_class(friend, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({'success': 'Friendship updated successfully'}, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def destroy(self, request, pk=None):
+        try:
+            friend = FriendList.objects.get(pk=pk)
+            if friend.status != 'accepted':
+                raise Exception('Users are not friends')
+        except FriendList.DoesNotExist:
+            return Response({'error': 'Friendship does not exist'}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        friend.delete()
+        return Response({'success': 'Friendship deleted successfully'}, status=status.HTTP_200_OK)
+
+
+
+class FriendListView(viewsets.ViewSet):
+    serializer_class = FriendListSerializer
+
+    def retrieve(self, request, pk=None):
+        users_data = FriendList.objects.select_related('friend').filter(status='accepted', user_id=pk)
+
+        # Convert the QuerySet to a list of dictionaries
+        friend_list = [
+            {
+                'id': user_data.friend.id,
+                'name': user_data.friend.name,
+                'surname': user_data.friend.surname,
+                'email': user_data.friend.email,
+            }
+            for user_data in users_data
+        ]
+
+        serializer = self.serializer_class(friend_list, many=True, partial=True)
+
+        return Response(serializer.data)
 
 
 @require_POST

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -29,6 +29,8 @@ router.register(r'products', views.ProductsViewSet, basename='products')
 router.register(r'cart', views.CartViewSet, basename='cart')
 router.register(r'profile', views.ProfileViewSet, basename='profile')
 router.register(r'calendar', views.CalendarViewSet, basename='calendar')
+router.register(r'friend', views.Friend, basename='friend')
+router.register(r'user-friend-list', views.FriendListView, basename='user-friend-list')
 
 
 urlpatterns = [


### PR DESCRIPTION
#57 

To database added new table for friend requests and friend listing as shown below:
![image](https://user-images.githubusercontent.com/94856001/211144754-bfa12ad0-aa38-4a43-8f76-8f77434ad950.png)

- To create friend request:

POST /api/friend/
with data:
```
{
  "user": 1,
  "friend": 2,
  "status": "pending"
}
```
It will create firend request for user with id 2.

- To update friend request:

PUT /api/friend/{id}/

Id is a friend request id. Data needed to be send is for example:
```
{
  "status": "rejected"
}
```
Status can be either chaned to rejected or accepted.

(Friend request listing will be done in this issue: #72)

- To delete friend request:

DELETE /api/friend/{id}/

Id is a friend request id.


To list friends:
GET /api/user-friend-list/{id}/

Id is an user id. Endpoint returns list of friends with thier user data