### PR TITLE
Builtin events, shopping carts per event

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -26,7 +26,7 @@ class Users(models.Model):
 class PaymentMethods(models.Model):
     name = models.CharField(max_length=255)
     image_url = models.CharField(max_length=255)
-    friend_request = models.ManyToManyField('self', through='FriendList', through_fields=('user', 'friend'), symmetrical=False)
+    # friend_request = models.ManyToManyField('self', through='FriendList', through_fields=('user', 'friend'), symmetrical=False)
 
 
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -58,11 +58,11 @@ class CalendarViewSet(viewsets.ModelViewSet):
         # TODO Currently getting user id from variable / django builtin auth, need to switch to @VV1S version of auth
         # user_id = self.request.user.id
         user_id = 1
-        queryset = UserEvents.objects.all().order_by('id')
+        builtin_id = 99999
+        queryset = UserEvents.objects.all().order_by('id').filter(Q(owner_id=user_id) | Q(owner_id=builtin_id))
         # TODO filtering is done by query params, if it's not ok then we need to find out how to filter by /year/month
         calendar_year = self.request.query_params.get('year')
         calendar_month = self.request.query_params.get('month')
-        print(calendar_month, calendar_year)
         if calendar_year and calendar_month and user_id is not None:
             queryset = queryset.filter(
                 Q(date__year=calendar_year) & Q(date__month=calendar_month) & Q(owner_id=user_id)
@@ -95,6 +95,7 @@ class ProductsViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
 class Friend(viewsets.ViewSet):
     serializer_class = FriendSerializer
 
@@ -107,7 +108,8 @@ class Friend(viewsets.ViewSet):
             if user == friend:
                 return Response({'error': 'User and friend cannot be the same'}, status=status.HTTP_400_BAD_REQUEST)
             if user.id < 1 or friend.id < 1:
-                return Response({'error': 'User and friend IDs cannot be less than 1'}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({'error': 'User and friend IDs cannot be less than 1'},
+                                status=status.HTTP_400_BAD_REQUEST)
             new_friendship = FriendList.objects.create(user=user, friend=friend, status=status_request)
             new_friendship.save()
             return Response({'success': 'Friendship created successfully'}, status=status.HTTP_201_CREATED)
@@ -139,7 +141,6 @@ class Friend(viewsets.ViewSet):
         return Response({'success': 'Friendship deleted successfully'}, status=status.HTTP_200_OK)
 
 
-
 class FriendListView(viewsets.ViewSet):
     serializer_class = FriendListSerializer
 
@@ -169,6 +170,7 @@ def get_random_records(model, num_records):
     random_records = records.order_by('?')[:num_records]
     return random_records
 
+
 class GiftDiscover(viewsets.ViewSet):
     serializer_class = GiftsSerializer
 
@@ -185,7 +187,8 @@ class IncomingGifts(viewsets.ViewSet):
         today = datetime.date.today()
         start_date = today
         end_date = today + datetime.timedelta(days=90)
-        shopping_carts = ShoppingCart.objects.select_related('id_event').filter(id_event__date__range=(start_date, end_date), id_event__owner_id=pk).order_by('id_event__date')[:10]
+        shopping_carts = ShoppingCart.objects.select_related('id_event').filter(
+            id_event__date__range=(start_date, end_date), id_event__owner_id=pk).order_by('id_event__date')[:10]
 
         # Convert the QuerySet to a list of dictionaries
         shopping_carts_list = [


### PR DESCRIPTION
-Shopping carts per event verified, it was already designed like this as every shopping cart has it's event id
-Builtin events implemented as a filter of calendar query, GET /api/calendar/ now returns events filtered to currently logged user and builtin events (builtin events has been implemented as a user)
-Commented out friend_request from models.py, it was added by someone to PaymentMethods class. It caused following errors:
ERRORS:
api.PaymentMethods.friend_request: (fields.E339) 'FriendList.friend' is not a foreign key to 'PaymentMethods'.
api.PaymentMethods.friend_request: (fields.E339) 'FriendList.user' is not a foreign key to 'PaymentMethods'.

Closes #73 #74